### PR TITLE
A slight optimized change

### DIFF
--- a/Nine Divisors.java
+++ b/Nine Divisors.java
@@ -11,7 +11,7 @@ class Solution{
         //fill sieve
         for(int i=2;i*i<=size;i++){
             if(prime[i]==i){
-                for(int j=i+i;j<=size;j+=i){
+                for(int j=i*i;j<=size;j+=i){
                     if(prime[j]==j){
                         prime[j]=i;
                     }


### PR DESCRIPTION
We don't need to start j from i+i, j can be started from i*i as all the values less than i*i would already have been marked by the prime numbers earlier. By this we can avoid reiterating the multiples of primes!